### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests
 tld
 xlwt
 grequests
-rich
+rich==11.0.0
 colorama
 pocsuite3
 colorlog


### PR DESCRIPTION
Fix `add_column() got an unexpected keyword argument 'overflow'`
原因： table.add_column() 中的 overflow 属性在较老版本的 rich 中没有。